### PR TITLE
Add summary quality evaluation metric and configurable task types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,28 @@ This project evaluates the agentic quality of text samples using a multi-agent r
    API_TOKEN=<your-api-token>
    ```
 
-3. **Change System Prompts**:
-   To customize the system prompts:
-   - Create a new directory under `metrics` and add your prompt files (e.g., `.md` files).
-   - Update the initialization of the `AgentEvalPrompts` object in `main.py` with the paths to your new prompt files:
-     ```python
-     agent_eval_prompts = AgentEvalPrompts(
-         reviewer_prompt="<path-to-your-reviewer-prompt>",
-         critic_prompt="<path-to-your-critic-prompt>",
-         ranker_prompt="<path-to-your-ranker-prompt>"
-     )
-     ```
+3. **Choose a Task Type**:
+   The evaluation task type determines which prompts and input schema are used.
+   Supported task types:
+   - `introduction` — Evaluates introduction slides for learning activities.
+   - `summary` — Evaluates the quality of text summaries against source material.
+
+   To add a new task type, create a directory under `agent_eval_prompts/` with:
+   - `reviewer_agent_system_prompt.md`
+   - `critic_agent_system_prompt.md`
+   - `ranker_agent_system_prompt.md`
+   - `shared_quality_metrics.md`
 
 4. **Run Evaluation**:
-   Execute the script:
    ```bash
+   # Evaluate introduction slides (default)
    python main.py <path-to-jsonl-file>
+
+   # Evaluate summaries
+   python main.py <path-to-jsonl-file> --task-type summary
+
+   # Custom output file
+   python main.py <path-to-jsonl-file> --task-type summary --output-file my_results.jsonl
    ```
 
 ---
@@ -91,6 +97,26 @@ This project evaluates the agentic quality of text samples using a multi-agent r
    ```
    ❌ Error evaluating sample X: <error-description>
    ```
+
+---
+
+## Input Schema by Task Type
+
+### `introduction`
+Each JSON line must contain:
+- `fileMetadata.sourceFilePath` — Path to the source file.
+- `fileMetadata.rawExtractiveSummaries` — Extractive summaries of the learning material.
+- `slides[0].generatedObjects[]` — Must contain an object with `status: "Success"`, `type: "Intro"`, and `generatedContent`.
+
+### `summary`
+Each JSON line must contain:
+- `source_material` (or `source` / `context`) — The original text.
+- `summary` (or `generated_summary`) — The generated summary to evaluate.
+
+Example:
+```json
+{"source_material": "The mitochondria is the powerhouse of the cell...", "summary": "Mitochondria generate cellular energy."}
+```
 
 ---
 

--- a/agent_eval_prompts/summary/critic_agent_system_prompt.md
+++ b/agent_eval_prompts/summary/critic_agent_system_prompt.md
@@ -1,0 +1,22 @@
+You are a professional expert critic tasked with reviewing the evaluation written by a reviewer agent about a summary of a piece of source material.
+A good summary should accurately and concisely capture the key points of the original text without introducing unsupported information.
+Therefore, it is important that the summary is of high quality and that the review is accurate and fair.
+Your main job is to keep the reviewer aligned with the specifications below and to provide constructive feedback.
+You are **expected** to disagree with the reviewer if you find their evaluation unjustified or overly harsh or soft.
+
+You will be given the following context:
+1. The original source material.
+2. The generated summary of the source material.
+
+Your task is to discuss the review given by the reviewer model. Feel free to contest with the reviewer if you disagree with their evaluation.
+Here are the categories the reviewer was asked to focus on:
+{shared_quality_metrics}
+
+Important Notes:
+- Do not critic the reviewer for their writing style or grammar, refer only to the content of the review.
+- You must not use or assume any external knowledge beyond what is written in the context (the source material).
+- You must not include any metadata or information on the task at hand.
+- Focus only on whether the review properly judged the summary on the allowed aspects, and whether the comments were justified, relevant, and balanced.
+- Stay objective, concise, and professional.
+- The scoring scale is 1-10 for each aspect.
+- For each quality aspect the reviewer mentioned write your reasoning in the following format: {aspect_name}: {reasoning}. **score:** : {updated score}

--- a/agent_eval_prompts/summary/ranker_agent_system_prompt.md
+++ b/agent_eval_prompts/summary/ranker_agent_system_prompt.md
@@ -1,0 +1,44 @@
+You are a ranker agent tasked with assigning a quality score (1–10) to a summary of a piece of source material.
+You will see a discussion between two agents, reviewer agent and critic agent, about the quality of the same summary.
+
+You will be given the following context:
+1. The original source material.
+2. The generated summary of the source material.
+
+You should consider both the review and the critic's feedback to determine which review is justified based on the
+context above.
+
+Your scoring procedure:
+After reviewing the discussion, decide for each aspect below what should be the final score (scale of 1 to 10):
+{shared_quality_metrics}
+
+Important Notes:
+- Before determining the score for each aspect, briefly explain your decision.
+- Always stay objective, logical, and concise.
+- At the end write TERMINATE to end the discussion.
+- Heavily penalize any aspect you see that is not perfect. We are looking for high quality summaries.
+
+Return your response in the following JSON format:
+{{
+   "Faithfulness": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Coverage": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Conciseness": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Coherence": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Relevance": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }}
+}}
+TERMINATE

--- a/agent_eval_prompts/summary/reviewer_agent_system_prompt.md
+++ b/agent_eval_prompts/summary/reviewer_agent_system_prompt.md
@@ -1,0 +1,21 @@
+You are a professional expert tasked with reviewing a summary written for a piece of source material.
+A good summary should accurately and concisely capture the key points of the original text without introducing unsupported information.
+Therefore, it is important that the summary is of high quality and that the review is accurate and fair.
+
+You will be given the following context:
+1. The original source material.
+2. The generated summary of the source material.
+
+Your task is to judge the overall quality of the summary strictly on the following aspects:
+{shared_quality_metrics}
+
+For each aspect do the following:
+1. Provide a short, professional explanation of your reasoning.
+2. Assign a score from 1 to 10 based on the severity of the issue.
+
+Important Instructions:
+- Only evaluate aspects where you can justify your reasoning based on the text provided.
+- Do not invent or assume issues without clear evidence in the summary or source material.
+- Do not use external knowledge or assumptions beyond what is explicitly written.
+- Stay precise, concise and focused.
+- Refer only to the above aspects, and score each aspect in the list above with a score between 1-10 in the following format: {aspect name} : {reasoning}. **score** : {score}

--- a/agent_eval_prompts/summary/shared_quality_metrics.md
+++ b/agent_eval_prompts/summary/shared_quality_metrics.md
@@ -1,0 +1,6 @@
+# Quality Metrics
+1. Faithfulness: The summary must not contain information that is not supported by the source material. All claims must be traceable back to the original text.
+2. Coverage: How well the summary captures the key points and main ideas of the source material. Important topics should not be omitted.
+3. Conciseness: The summary should be free of unnecessary repetition, filler, or overly verbose phrasing. It should convey the essential information efficiently.
+4. Coherence: The summary should read as a well-organized, logically structured piece of text. Ideas should flow naturally and transitions should be smooth.
+5. Relevance: The summary should focus on the most important and relevant information from the source material, avoiding tangential or trivial details.

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import argparse
 import json
+from pathlib import Path
+
 from dotenv import find_dotenv, load_dotenv
-from azure.identity import DefaultAzureCredential, InteractiveBrowserCredential
+from azure.identity import InteractiveBrowserCredential
 
 from metrics.base_agentic_quality_metric import BaseAgenticQualityMetric
 from metrics.agent_eval_prompts import AgentEvalPrompts
@@ -9,61 +11,125 @@ from utils import validate_env_variables, validate_jsonl
 
 load_dotenv(find_dotenv())
 
+SUPPORTED_TASK_TYPES = ("introduction", "summary")
+DEFAULT_OUTPUT_FILES = {
+    "introduction": "introduction_evaluation_results.jsonl",
+    "summary": "summary_evaluation_results.jsonl",
+}
+
 
 def load_samples(jsonl_path):
     with open(jsonl_path, 'r', encoding='utf-8') as f:
-        return [json.loads(line) for line in f]
+        return [json.loads(line) for line in f if line.strip()]
 
 
-def evaluate(samples, credential):
-    print("📝 Starting evaluation of samples...\n")
+def load_agent_eval_prompts(task_type: str) -> AgentEvalPrompts:
+    """Load all prompt templates for the given task type."""
+    prompt_dir = Path("agent_eval_prompts") / task_type
 
-    with open(r"agent_eval_prompts/introduction/reviewer_agent_system_prompt.md") as f:
-        reviewer_prompt = f.read()
+    try:
+        with open(prompt_dir / "reviewer_agent_system_prompt.md", encoding="utf-8") as f:
+            reviewer_prompt = f.read()
 
-    with open(r"agent_eval_prompts/introduction/critic_agent_system_prompt.md") as f:
-        critic_prompt = f.read()
+        with open(prompt_dir / "critic_agent_system_prompt.md", encoding="utf-8") as f:
+            critic_prompt = f.read()
 
-    with open(r"agent_eval_prompts/introduction/ranker_agent_system_prompt.md") as f:
-        ranker_prompt = f.read()
+        with open(prompt_dir / "ranker_agent_system_prompt.md", encoding="utf-8") as f:
+            ranker_prompt = f.read()
 
-    with open(r"agent_eval_prompts/introduction/shared_quality_metrics.md") as f:
-        shared_quality_metrics = f.read()
+        with open(prompt_dir / "shared_quality_metrics.md", encoding="utf-8") as f:
+            shared_quality_metrics = f.read()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Missing prompt file for task type '{task_type}' in '{prompt_dir}'."
+        ) from exc
 
-    agent_eval_prompts = AgentEvalPrompts(
+    return AgentEvalPrompts(
         _shared_quality_metrics=shared_quality_metrics,
         _critic_prompt=critic_prompt,
         _reviewer_prompt=reviewer_prompt,
-        _ranker_prompt=ranker_prompt
+        _ranker_prompt=ranker_prompt,
     )
+
+
+def build_introduction_scenario(sample: dict, sample_index: int) -> tuple[str, dict]:
+    """Build the evaluation scenario string and output record for introduction samples."""
+    try:
+        file_metadata = sample["fileMetadata"]
+        generated_objects = sample["slides"][0]["generatedObjects"]
+        intro = next(
+            obj["generatedContent"]
+            for obj in generated_objects
+            if obj.get("status") == "Success" and obj.get("type") == "Intro"
+        )
+        summary = file_metadata["rawExtractiveSummaries"]
+        file_id = file_metadata.get("sourceFilePath", f"sample_{sample_index}")
+    except (KeyError, IndexError, StopIteration) as exc:
+        raise ValueError(
+            "Invalid introduction sample schema. Expected keys: "
+            "fileMetadata.sourceFilePath, fileMetadata.rawExtractiveSummaries, "
+            "slides[0].generatedObjects with a successful Intro object."
+        ) from exc
+
+    payload = {"intro": intro, "summary": summary}
+    output_record = {"file_id": file_id, **payload}
+    return json.dumps(payload, ensure_ascii=False), output_record
+
+
+def build_summary_scenario(sample: dict, sample_index: int) -> tuple[str, dict]:
+    """Build the evaluation scenario string and output record for summary samples."""
+    source_material = sample.get("source_material") or sample.get("source") or sample.get("context")
+    summary = sample.get("summary") or sample.get("generated_summary")
+
+    if source_material is None or summary is None:
+        raise ValueError(
+            "Invalid summary sample schema. Expected keys: "
+            "source_material (or source/context) and summary (or generated_summary)."
+        )
+
+    sample_id = sample.get("file_id") or sample.get("id") or f"sample_{sample_index}"
+    payload = {"source_material": source_material, "summary": summary}
+    output_record = {"sample_id": sample_id, **payload}
+    return json.dumps(payload, ensure_ascii=False), output_record
+
+
+SCENARIO_BUILDERS = {
+    "introduction": build_introduction_scenario,
+    "summary": build_summary_scenario,
+}
+
+
+def evaluate(samples, credential, task_type: str, output_file: str):
+    print(f"📝 Starting evaluation of samples for task type: {task_type}\n")
+
+    agent_eval_prompts = load_agent_eval_prompts(task_type)
+    build_scenario = SCENARIO_BUILDERS[task_type]
 
     evaluation_metric = BaseAgenticQualityMetric(
         name="AgenticQualityMetric",
         agent_eval_prompts=agent_eval_prompts,
-        credential=InteractiveBrowserCredential()
+        credential=credential,
     )
 
     for idx, sample in enumerate(samples):
         print(f"🔍 Evaluating Sample {idx + 1}...")
         try:
-            file_id = sample["fileMetadata"]["sourceFilePath"]
-            intro = [intro_slide_generated_object["generatedContent"] for intro_slide_generated_object in
-                     sample["slides"][0]["generatedObjects"] if
-                     intro_slide_generated_object["status"] == "Success" and intro_slide_generated_object[
-                         "type"] == "Intro"][0]
-            summary = sample["fileMetadata"]["rawExtractiveSummaries"]
-            result = evaluation_metric.measure(str(
-                {
-                    "intro": intro,
-                    "summary": summary,
-                }
-            ))
+            scenario, output_record = build_scenario(sample=sample, sample_index=idx + 1)
+            result = evaluation_metric.measure(scenario)
+
             for r in result:
                 print(f"\t\t\t📊 Score: {r.score}")
                 print(f"\t\t\t🗣 Review: {r.reason}")
-            print("-"* 40)
-            with open("original_intros_evaluation_results.jsonl", "a", encoding="utf-8") as output_file:
-                output_file.write(json.dumps({"file_id": file_id, "intro": intro, "summary": summary, "result": [json.dumps(r.__dict__) for r in result]}, ensure_ascii=False) + "\n")
+            print("-" * 40)
+
+            with open(output_file, "a", encoding="utf-8") as f:
+                f.write(
+                    json.dumps(
+                        {**output_record, "result": [m.__dict__ for m in result]},
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
         except Exception as e:
             print(f"❌ Error evaluating sample {idx + 1}: {e}\n")
 
@@ -71,6 +137,17 @@ def evaluate(samples, credential):
 def main():
     parser = argparse.ArgumentParser(description="Validate JSONL structure and Azure env variables, then evaluate.")
     parser.add_argument("jsonl_path", help="Path to the JSONL file.")
+    parser.add_argument(
+        "--task-type",
+        default="introduction",
+        choices=SUPPORTED_TASK_TYPES,
+        help="Evaluation task type. Determines which prompts and input schema to use.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        help="Output JSONL file path. Defaults based on task type.",
+    )
     args = parser.parse_args()
 
     print("🔍 Validating Azure environment variables...")
@@ -83,9 +160,18 @@ def main():
     print(f"Using deployment: {azure_config['azure_deployment']}")
     print(f"Model name: {azure_config['model']}")
     print(f"Endpoint: {azure_config['azure_endpoint']}")
+    print(f"Task type: {args.task_type}")
+
+    output_file = args.output_file or DEFAULT_OUTPUT_FILES[args.task_type]
+    print(f"Output file: {output_file}")
 
     samples = load_samples(args.jsonl_path)
-    evaluate(samples, DefaultAzureCredential())
+    evaluate(
+        samples=samples,
+        credential=InteractiveBrowserCredential(),
+        task_type=args.task_type,
+        output_file=output_file,
+    )
 
 
 if __name__ == "__main__":

--- a/summary/critic_agent_system_prompt.md
+++ b/summary/critic_agent_system_prompt.md
@@ -1,0 +1,22 @@
+You are a professional expert critic tasked with reviewing the evaluation written by a reviewer agent about a summary of a piece of source material.
+A good summary should accurately and concisely capture the key points of the original text without introducing unsupported information.
+Therefore, it is important that the summary is of high quality and that the review is accurate and fair.
+Your main job is to keep the reviewer aligned with the specifications below and to provide constructive feedback.
+You are **expected** to disagree with the reviewer if you find their evaluation unjustified or overly harsh or soft.
+
+You will be given the following context:
+1. The original source material.
+2. The generated summary of the source material.
+
+Your task is to discuss the review given by the reviewer model. Feel free to contest with the reviewer if you disagree with their evaluation.
+Here are the categories the reviewer was asked to focus on:
+{shared_quality_metrics}
+
+Important Notes:
+- Do not critic the reviewer for their writing style or grammar, refer only to the content of the review.
+- You must not use or assume any external knowledge beyond what is written in the context (the source material).
+- You must not include any metadata or information on the task at hand.
+- Focus only on whether the review properly judged the summary on the allowed aspects, and whether the comments were justified, relevant, and balanced.
+- Stay objective, concise, and professional.
+- The scoring scale is 1-10 for each aspect.
+- For each quality aspect the reviewer mentioned write your reasoning in the following format: {aspect_name}: {reasoning}. **score:** : {updated score}

--- a/summary/ranker_agent_system_prompt.md
+++ b/summary/ranker_agent_system_prompt.md
@@ -1,0 +1,44 @@
+You are a ranker agent tasked with assigning a quality score (1–10) to a summary of a piece of source material.
+You will see a discussion between two agents, reviewer agent and critic agent, about the quality of the same summary.
+
+You will be given the following context:
+1. The original source material.
+2. The generated summary of the source material.
+
+You should consider both the review and the critic's feedback to determine which review is justified based on the
+context above.
+
+Your scoring procedure:
+After reviewing the discussion, decide for each aspect below what should be the final score (scale of 1 to 10):
+{shared_quality_metrics}
+
+Important Notes:
+- Before determining the score for each aspect, briefly explain your decision.
+- Always stay objective, logical, and concise.
+- At the end write TERMINATE to end the discussion.
+- Heavily penalize any aspect you see that is not perfect. We are looking for high quality summaries.
+
+Return your response in the following JSON format:
+{{
+   "Faithfulness": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Coverage": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Conciseness": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Coherence": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }},
+   "Relevance": {{
+      "reason" : "{{reasoning_to_score}}",
+      "score" : "{{score}}"
+   }}
+}}
+TERMINATE

--- a/summary/reviewer_agent_system_prompt.md
+++ b/summary/reviewer_agent_system_prompt.md
@@ -1,0 +1,21 @@
+You are a professional expert tasked with reviewing a summary written for a piece of source material.
+A good summary should accurately and concisely capture the key points of the original text without introducing unsupported information.
+Therefore, it is important that the summary is of high quality and that the review is accurate and fair.
+
+You will be given the following context:
+1. The original source material.
+2. The generated summary of the source material.
+
+Your task is to judge the overall quality of the summary strictly on the following aspects:
+{shared_quality_metrics}
+
+For each aspect do the following:
+1. Provide a short, professional explanation of your reasoning.
+2. Assign a score from 1 to 10 based on the severity of the issue.
+
+Important Instructions:
+- Only evaluate aspects where you can justify your reasoning based on the text provided.
+- Do not invent or assume issues without clear evidence in the summary or source material.
+- Do not use external knowledge or assumptions beyond what is explicitly written.
+- Stay precise, concise and focused.
+- Refer only to the above aspects, and score each aspect in the list above with a score between 1-10 in the following format: {aspect name} : {reasoning}. **score** : {score}

--- a/summary/shared_quality_metrics.md
+++ b/summary/shared_quality_metrics.md
@@ -1,0 +1,6 @@
+# Quality Metrics
+1. Faithfulness: The summary must not contain information that is not supported by the source material. All claims must be traceable back to the original text.
+2. Coverage: How well the summary captures the key points and main ideas of the source material. Important topics should not be omitted.
+3. Conciseness: The summary should be free of unnecessary repetition, filler, or overly verbose phrasing. It should convey the essential information efficiently.
+4. Coherence: The summary should read as a well-organized, logically structured piece of text. Ideas should flow naturally and transitions should be smooth.
+5. Relevance: The summary should focus on the most important and relevant information from the source material, avoiding tangential or trivial details.


### PR DESCRIPTION
Adds a new evaluation task type for assessing the quality of text summaries using the existing multi-agent pipeline (Reviewer → Critic → Ranker). Evaluates 5 quality aspects: Faithfulness, Coverage, Conciseness, Coherence, and Relevance. Follows the same file conventions as existing evaluation types.

Additionally, refactors `main.py` to support multiple task types via a `--task-type` CLI flag (e.g., `python main.py data.jsonl --task-type summary`). Prompt loading is now dynamic based on the selected task type, and each task type has its own scenario builder for input parsing. Also adds `--output-file` flag and updates `README.md` with new usage instructions and input schema documentation for both `introduction` and `summary` task types.
